### PR TITLE
On dissocie la fonction modalinit() du window.onload

### DIFF
--- a/modal.js
+++ b/modal.js
@@ -1,6 +1,6 @@
 // CETTE PAGE SERT A FAIRE FONCTIONNER LES MODAL POPUP PRESENTE DANS LA PAGE POCHETTES.HTML
 
-window.onload = function modalinit() {
+function modalinit() {
     var modals = document.getElementsByClassName("modal");
 
     for (let index = 0; index < modals.length; index++) {
@@ -20,6 +20,8 @@ window.onload = function modalinit() {
         }
     };
 };
+
+window.onload = modalinit();
 
 
 // When the user clicks anywhere outside of the modal, close it


### PR DESCRIPTION
Après ce changement, on peut faire appel à la fonction `modalinit()` à tout moment – pas uniquement sur l'événement `window.onload`. 

Cela permet au code déjà existant (`barba.hooks.enter`...) de fonctionner.

Corrige l'issue  #18